### PR TITLE
auto generate docs and deploy to github pages

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 20.12.0
         registry-url: 'https://registry.npmjs.org'
         scope: '@jpyc'
     - name: Install dependencies

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check format
         run: |
           yarn run format:dry-run docs
-          yarn workspace @jpyc/sdk-core run format:dry-run
+
   build:
     needs: format
     runs-on: ubuntu-latest
@@ -40,17 +40,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
-
-      - uses: ./.github/actions/install-dependencies
-
-      - name: Generate documentation
-        run: |
-          echo "Generating documentation..."
-          set -x
-          yarn docs || {
-            echo "Documentation generation failed"
-            exit 1
-          }
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs/core-html'
+          path: './docs/core/html'
 
   deploy:
     needs: build

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  format:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,10 +28,20 @@ jobs:
 
       - uses: ./.github/actions/install-dependencies
 
-      - name: Format documentation
+      - name: Check format
         run: |
-          yarn run format docs
-          yarn workspace @jpyc/sdk-core run format
+          yarn run format:dry-run docs
+          yarn workspace @jpyc/sdk-core run format:dry-run
+  build:
+    needs: format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - uses: ./.github/actions/install-dependencies
 
       - name: Generate documentation
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'packages/*/src/**'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,69 @@
+name: deploy documentation
+
+on:
+  push:
+    branches: ['develop']
+    paths:
+      - 'docs/**'
+      - 'packages/*/src/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.12.0'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Format documentation
+        run: |
+          yarn run format docs
+          yarn workspace @jpyc/sdk-core run format
+
+      - name: Generate documentation
+        run: |
+          echo "Generating documentation..."
+          set -x
+          yarn docs || {
+            echo "Documentation generation failed"
+            exit 1
+          }
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs/core-html'
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,9 +2,9 @@ name: deploy documentation
 
 on:
   push:
-    branches: ['develop']
+    branches:
+      - 'main'
     paths:
-      - 'docs/**'
       - 'packages/*/src/**'
   workflow_dispatch:
 
@@ -26,14 +26,7 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.12.0'
-          cache: 'yarn'
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/install-dependencies
 
       - name: Format documentation
         run: |

--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -6,3 +6,4 @@ cache
 artifacts
 node_modules
 JPYCv2
+docs/core-html/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,8 +37,8 @@
     "format": "prettier --write .",
     "format:dry-run": "prettier --check .",
     "docs": "yarn docs:md && yarn docs:html",
-    "docs:md": "typedoc --plugin typedoc-plugin-markdown --out ../../docs/core",
-    "docs:html": "typedoc --out ../../docs/core-html"
+    "docs:md": "typedoc --plugin typedoc-plugin-markdown --out ../../docs/core/md",
+    "docs:html": "typedoc --out ../../docs/core/html"
   },
   "dependencies": {
     "dotenv": "^16.4.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "lint:dry-run": "eslint ./src",
     "format": "prettier --write .",
     "format:dry-run": "prettier --check .",
-    "docs": "yarn docs:md && yarn docs:html",
+    "docs": "run-p docs:md docs:html",
     "docs:md": "typedoc --plugin typedoc-plugin-markdown --out ../../docs/core/md",
     "docs:html": "typedoc --out ../../docs/core/html"
   },
@@ -55,6 +55,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "jest": "^29.7.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "^3.4.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,9 @@
     "lint:dry-run": "eslint ./src",
     "format": "prettier --write .",
     "format:dry-run": "prettier --check .",
-    "docs": "typedoc"
+    "docs": "yarn docs:md && yarn docs:html",
+    "docs:md": "typedoc --plugin typedoc-plugin-markdown --out ../../docs/core",
+    "docs:html": "typedoc --out ../../docs/core-html"
   },
   "dependencies": {
     "dotenv": "^16.4.6",

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,3 @@
 {
-  "plugin": ["typedoc-plugin-markdown"],
   "cleanOutputDir": false
 }


### PR DESCRIPTION
# 🎨 Overview
Implement auto-generation of documentation and modified the documentation generation to output both HTML (for GitHub Pages) and Markdown (for GitHub) formats.

# 🌈 Details
- Implement workflow file `deploy-docs.yml` for git action to deploy docs to github pages
- Configure to generate Markdown documentation under `/docs/core` - for GitHub repository viewing
- Configure to generate HTML documentation under `/docs/core-html` - for GitHub Pages hosting
- Update TypeDoc configurations:
 - Remove `plugin` setting from root `typedoc.json`, keeping only essential configs
 - Add `docs:md` and `docs:html` scripts to `packages/core`
 - Set HTML documentation output directory to `core-html`
- Add `docs/core-html` to `.prettierignore` to exclude from formatting checks

# 📚 References
- Issue #59: Enable Auto-Deployments of Docs/Specs
- Previous related PRs: #74, #75, #76, #77, #78, #81

This change enables proper generation and management of both Markdown documentation for GitHub viewing and HTML documentation for GitHub Pages.