### PR TITLE
fix(chains): replace baseSepolia with sepolia for Ethereum testnet

### DIFF
--- a/packages/core/src/utils/chains.ts
+++ b/packages/core/src/utils/chains.ts
@@ -2,7 +2,7 @@ import { Chain, defineChain } from 'viem';
 import {
   mainnet,
   goerli,
-  baseSepolia,
+  sepolia,
   polygon,
   polygonAmoy,
   gnosis,
@@ -37,7 +37,7 @@ export const SUPPORTED_CHAINS: Record<string, Record<string, Chain>> = {
   ethereum: {
     mainnet: mainnet,
     goerli: goerli,
-    sepolia: baseSepolia,
+    sepolia: sepolia,
   },
   polygon: {
     mainnet: polygon,


### PR DESCRIPTION
## 🎨 Overview
Replace incorrect baseSepolia with sepolia chain configuration for Ethereum testnet transactions to ensure proper network connectivity and transaction handling.

## 🌈 Details
- Update `SUPPORTED_CHAINS.ethereum.sepolia` to use the correct Sepolia testnet chain
- Replace import of `baseSepolia` with `sepolia` from `viem/chains`
- Remove unused `baseSepolia` import
- Ensure transactions are properly routed to Ethereum L1 Sepolia testnet instead of Base L2 testnet

## 📚 References
- [viem chains documentation](https://viem.sh/docs/chains/introduction.html)
- [Sepolia Testnet Information](https://sepolia.dev/)
- [Base Sepolia Documentation](https://docs.base.org/tools/sepolia)