### PR TITLE
Fix Decimals Handling

### DIFF
--- a/packages/core/src/interfaces/jpyc.ts
+++ b/packages/core/src/interfaces/jpyc.ts
@@ -22,14 +22,14 @@ export interface IJPYC {
    * @param minter - Minter address
    * @returns minter allowance
    */
-  minterAllowance(params: { minter: Address }): Promise<Uint256>;
+  minterAllowance(params: { minter: Address }): Promise<number>;
 
   /**
    * Returns total supply of JPYC tokens.
    *
    * @returns total supply
    */
-  totalSupply(): Promise<Uint256>;
+  totalSupply(): Promise<number>;
 
   /**
    * Returns balance of an account.
@@ -37,7 +37,7 @@ export interface IJPYC {
    * @param account - Account address
    * @returns account balance
    */
-  balanceOf(params: { account: Address }): Promise<Uint256>;
+  balanceOf(params: { account: Address }): Promise<number>;
 
   /**
    * Returns allowance of a spender over owner's tokens (for transferring).
@@ -46,7 +46,7 @@ export interface IJPYC {
    * @param spender - Spender address
    * @returns spender allowance
    */
-  allowance(params: { owner: Address; spender: Address }): Promise<Uint256>;
+  allowance(params: { owner: Address; spender: Address }): Promise<number>;
 
   /**
    * Returns nonce for EIP2612's `permit`.
@@ -67,7 +67,7 @@ export interface IJPYC {
    * @param minterAllowedAmount - Minter allowance
    * @returns transaction hash
    */
-  configureMinter(params: { minter: Address; minterAllowedAmount: Uint256 }): Promise<Hash>;
+  configureMinter(params: { minter: Address; minterAllowedAmount: number }): Promise<Hash>;
 
   /**
    * Mints tokens.
@@ -76,7 +76,7 @@ export interface IJPYC {
    * @param amount - Amount of tokens to mint
    * @returns transaction hash
    */
-  mint(params: { to: Address; amount: Uint256 }): Promise<Hash>;
+  mint(params: { to: Address; amount: number }): Promise<Hash>;
 
   /**
    * Transfers tokens (directly).
@@ -85,7 +85,7 @@ export interface IJPYC {
    * @param value - Amount of tokens to transfer
    * @returns transaction hash
    */
-  transfer(params: { to: Address; value: Uint256 }): Promise<Hash>;
+  transfer(params: { to: Address; value: number }): Promise<Hash>;
 
   /**
    * Transfers tokens (from spender).
@@ -95,7 +95,7 @@ export interface IJPYC {
    * @param value - Amount of tokens to transfer
    * @returns transaction hash
    */
-  transferFrom(params: { from: Address; to: Address; value: Uint256 }): Promise<Hash>;
+  transferFrom(params: { from: Address; to: Address; value: number }): Promise<Hash>;
 
   /**
    * Transfers tokens with authorization.
@@ -114,7 +114,7 @@ export interface IJPYC {
   transferWithAuthorization(params: {
     from: Address;
     to: Address;
-    value: Uint256;
+    value: number;
     validAfter: Uint256;
     validBefore: Uint256;
     nonce: Bytes32;
@@ -140,7 +140,7 @@ export interface IJPYC {
   receiveWithAuthorization(params: {
     from: Address;
     to: Address;
-    value: Uint256;
+    value: number;
     validAfter: Uint256;
     validBefore: Uint256;
     nonce: Bytes32;
@@ -174,7 +174,7 @@ export interface IJPYC {
    * @param value - Amount of allowance
    * @returns transaction hash
    */
-  approve(params: { spender: Address; value: Uint256 }): Promise<Hash>;
+  approve(params: { spender: Address; value: number }): Promise<Hash>;
 
   /**
    * Increases allowance.
@@ -183,7 +183,7 @@ export interface IJPYC {
    * @param increment - Amount of allowance to increase
    * @returns transaction hash
    */
-  increaseAllowance(params: { spender: Address; increment: Uint256 }): Promise<Hash>;
+  increaseAllowance(params: { spender: Address; increment: number }): Promise<Hash>;
 
   /**
    * Decreases allowance.
@@ -192,7 +192,7 @@ export interface IJPYC {
    * @param increment - Amount of allowance to decrease
    * @returns transaction hash
    */
-  decreaseAllowance(params: { spender: Address; decrement: Uint256 }): Promise<Hash>;
+  decreaseAllowance(params: { spender: Address; decrement: number }): Promise<Hash>;
 
   /**
    * Sets allowance of a spender over owner's tokens, given owner's signed approval.
@@ -209,7 +209,7 @@ export interface IJPYC {
   permit(params: {
     owner: Address;
     spender: Address;
-    value: Uint256;
+    value: number;
     deadline: Uint256;
     v: Uint8;
     r: Bytes32;

--- a/packages/core/src/jpyc.ts
+++ b/packages/core/src/jpyc.ts
@@ -54,7 +54,7 @@ export class JPYC implements IJPYC {
 
   async balanceOf(params: { account: Address }): Promise<Uint256> {
     const resp = await this.contract.read.balanceOf([params.account]);
-    const rawBalance = BigInt(resp.toString());
+    const rawBalance = BigInt((resp as bigint).toString());
     const adjustedBalance = rawBalance / BigInt(10 ** this.DECIMALS);
     return Uint256.from(adjustedBalance.toString());
   }

--- a/packages/core/src/jpyc.ts
+++ b/packages/core/src/jpyc.ts
@@ -4,7 +4,7 @@ import { getContract, GetContractReturnType, Hash, WalletClient } from 'viem';
 import { IJPYC, JPYC_V2_ABI } from './interfaces';
 import {
   Address,
-  addDecimals,
+  restoreDecimals,
   Bytes32,
   InvalidAddressError,
   InvalidTransactionError,
@@ -45,25 +45,25 @@ export class JPYC implements IJPYC {
   async minterAllowance(params: { minter: Address }): Promise<number> {
     const resp = await this.contract.read.minterAllowance([params.minter]);
 
-    return addDecimals(Uint256.from(resp as string));
+    return restoreDecimals(Uint256.from(resp as string));
   }
 
   async totalSupply(): Promise<number> {
     const resp = await this.contract.read.totalSupply();
 
-    return addDecimals(Uint256.from(resp as string));
+    return restoreDecimals(Uint256.from(resp as string));
   }
 
   async balanceOf(params: { account: Address }): Promise<number> {
     const resp = await this.contract.read.balanceOf([params.account]);
 
-    return addDecimals(Uint256.from(resp as string));
+    return restoreDecimals(Uint256.from(resp as string));
   }
 
   async allowance(params: { owner: Address; spender: Address }): Promise<number> {
     const resp = await this.contract.read.allowance([params.owner, params.spender]);
 
-    return addDecimals(Uint256.from(resp as string));
+    return restoreDecimals(Uint256.from(resp as string));
   }
 
   async nonces(params: { owner: Address }): Promise<Uint256> {

--- a/packages/core/src/jpyc.ts
+++ b/packages/core/src/jpyc.ts
@@ -31,6 +31,21 @@ export class JPYC implements IJPYC {
   }
 
   /**
+   * Helper functions for decimal handling
+   */
+
+  private fromOnChainValue(value: bigint): Uint256 {
+    const adjustedValue = value / BigInt(10 ** this.DECIMALS);
+    return Uint256.from(adjustedValue.toString());
+  }
+
+  private toOnChainValue(value: Uint256): Uint256 {
+    const rawValue = BigInt(value.toString());
+    const adjustedValue = rawValue * BigInt(10 ** this.DECIMALS);
+    return Uint256.from(adjustedValue.toString());
+  }
+
+  /**
    * View Functions
    */
 
@@ -43,26 +58,25 @@ export class JPYC implements IJPYC {
   async minterAllowance(params: { minter: Address }): Promise<Uint256> {
     const resp = await this.contract.read.minterAllowance([params.minter]);
 
-    return Uint256.from((resp as bigint).toString());
+    return this.fromOnChainValue(resp as bigint);
   }
 
   async totalSupply(): Promise<Uint256> {
     const resp = await this.contract.read.totalSupply();
 
-    return Uint256.from((resp as bigint).toString());
+    return this.fromOnChainValue(resp as bigint);
   }
 
   async balanceOf(params: { account: Address }): Promise<Uint256> {
     const resp = await this.contract.read.balanceOf([params.account]);
-    const rawBalance = BigInt((resp as bigint).toString());
-    const adjustedBalance = rawBalance / BigInt(10 ** this.DECIMALS);
-    return Uint256.from(adjustedBalance.toString());
+
+    return this.fromOnChainValue(resp as bigint);
   }
 
   async allowance(params: { owner: Address; spender: Address }): Promise<Uint256> {
     const resp = await this.contract.read.allowance([params.owner, params.spender]);
 
-    return Uint256.from((resp as bigint).toString());
+    return this.fromOnChainValue(resp as bigint);
   }
 
   async nonces(params: { owner: Address }): Promise<Uint256> {
@@ -88,7 +102,8 @@ export class JPYC implements IJPYC {
   }
 
   async mint(params: { to: Address; amount: Uint256 }): Promise<Hash> {
-    const args = [params.to, params.amount];
+    const adjustedAmount = this.toOnChainValue(params.amount);
+    const args = [params.to, adjustedAmount];
 
     try {
       await this.contract.simulate.mint(args);
@@ -100,9 +115,8 @@ export class JPYC implements IJPYC {
   }
 
   async transfer(params: { to: Address; value: Uint256 }): Promise<Hash> {
-    const rawValue = BigInt(params.value.toString());
-    const adjustedValue = rawValue * BigInt(10 ** this.DECIMALS);
-    const args = [params.to, Uint256.from(adjustedValue.toString())];
+    const adjustedValue = this.toOnChainValue(params.value);
+    const args = [params.to, adjustedValue];
 
     try {
       await this.contract.simulate.transfer(args);
@@ -114,7 +128,8 @@ export class JPYC implements IJPYC {
   }
 
   async transferFrom(params: { from: Address; to: Address; value: Uint256 }): Promise<Hash> {
-    const args = [params.from, params.to, params.value];
+    const adjustedValue = this.toOnChainValue(params.value);
+    const args = [params.from, params.to, adjustedValue];
 
     try {
       await this.contract.simulate.transferFrom(args);
@@ -136,10 +151,11 @@ export class JPYC implements IJPYC {
     r: Bytes32;
     s: Bytes32;
   }): Promise<Hash> {
+    const adjustedValue = this.toOnChainValue(params.value);
     const args = [
       params.from,
       params.to,
-      params.value,
+      adjustedValue,
       params.validAfter,
       params.validBefore,
       params.nonce,
@@ -168,10 +184,11 @@ export class JPYC implements IJPYC {
     r: Bytes32;
     s: Bytes32;
   }): Promise<Hash> {
+    const adjustedValue = this.toOnChainValue(params.value);
     const args = [
       params.from,
       params.to,
-      params.value,
+      adjustedValue,
       params.validAfter,
       params.validBefore,
       params.nonce,
@@ -208,7 +225,8 @@ export class JPYC implements IJPYC {
   }
 
   async approve(params: { spender: Address; value: Uint256 }): Promise<Hash> {
-    const args = [params.spender, params.value];
+    const adjustedValue = this.toOnChainValue(params.value);
+    const args = [params.spender, adjustedValue];
 
     try {
       await this.contract.simulate.approve(args);
@@ -220,7 +238,8 @@ export class JPYC implements IJPYC {
   }
 
   async increaseAllowance(params: { spender: Address; increment: Uint256 }): Promise<Hash> {
-    const args = [params.spender, params.increment];
+    const adjustedIncrement = this.toOnChainValue(params.increment);
+    const args = [params.spender, adjustedIncrement];
 
     try {
       await this.contract.simulate.increaseAllowance(args);
@@ -232,7 +251,8 @@ export class JPYC implements IJPYC {
   }
 
   async decreaseAllowance(params: { spender: Address; decrement: Uint256 }): Promise<Hash> {
-    const args = [params.spender, params.decrement];
+    const adjustedDecrement = this.toOnChainValue(params.decrement);
+    const args = [params.spender, adjustedDecrement];
 
     try {
       await this.contract.simulate.decreaseAllowance(args);
@@ -252,10 +272,11 @@ export class JPYC implements IJPYC {
     r: Bytes32;
     s: Bytes32;
   }): Promise<Hash> {
+    const adjustedValue = this.toOnChainValue(params.value);
     const args = [
       params.owner,
       params.spender,
-      params.value,
+      adjustedValue,
       params.deadline,
       params.v,
       params.r,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './addresses';
 export * from './chains';
 export * from './errors';
+export * from './math';
 export * from './types';

--- a/packages/core/src/utils/math.test.ts
+++ b/packages/core/src/utils/math.test.ts
@@ -1,0 +1,33 @@
+import { Uint256 } from 'soltypes';
+
+import { toUint256, removeDecimals, addDecimals } from './math';
+
+describe('Unit tests of toUint256()', () => {
+  test('converts bigint to uint256 value', () => {
+    const res = toUint256(123456789n);
+    expect(res).toBeInstanceOf(Uint256);
+    expect(res.toString()).toStrictEqual('123456789');
+  });
+});
+
+describe('Unit tests of removeDecimals()', () => {
+  test('removes decimal places from a decimal', () => {
+    const res = removeDecimals(0.01);
+    expect(res).toBeInstanceOf(Uint256);
+    expect(res.toString()).toStrictEqual('10000000000000000');
+  });
+
+  test('removes decimal places from an integer (no decimal places)', () => {
+    const res = removeDecimals(100);
+    expect(res).toBeInstanceOf(Uint256);
+    expect(res.toString()).toStrictEqual('100000000000000000000');
+  });
+});
+
+describe('Unit tests of addDecimals()', () => {
+  test('adds decimal places to bigint', () => {
+    const res = addDecimals(Uint256.from('100'));
+    expect(typeof res).toBe('number');
+    expect(res).toStrictEqual(0.0000000000000001);
+  });
+});

--- a/packages/core/src/utils/math.test.ts
+++ b/packages/core/src/utils/math.test.ts
@@ -1,6 +1,6 @@
 import { Uint256 } from 'soltypes';
 
-import { toUint256, removeDecimals, addDecimals } from './math';
+import { toUint256, removeDecimals, restoreDecimals } from './math';
 
 describe('Unit tests of toUint256()', () => {
   test('converts bigint to uint256 value', () => {
@@ -24,9 +24,9 @@ describe('Unit tests of removeDecimals()', () => {
   });
 });
 
-describe('Unit tests of addDecimals()', () => {
-  test('adds decimal places to bigint', () => {
-    const res = addDecimals(Uint256.from('100'));
+describe('Unit tests of restoreDecimals()', () => {
+  test('restores decimal places to bigint', () => {
+    const res = restoreDecimals(Uint256.from('100'));
     expect(typeof res).toBe('number');
     expect(res).toStrictEqual(0.0000000000000001);
   });

--- a/packages/core/src/utils/math.ts
+++ b/packages/core/src/utils/math.ts
@@ -1,0 +1,16 @@
+import { Uint256 } from 'soltypes';
+
+const TOKEN_DECIMALS = 18;
+const DECIMALS_QUANTIFIER = 10 ** TOKEN_DECIMALS;
+
+export const toUint256 = (value: bigint): Uint256 => {
+  return Uint256.from(value.toString());
+};
+
+export const removeDecimals = (value: number): Uint256 => {
+  return toUint256(BigInt(value * DECIMALS_QUANTIFIER));
+};
+
+export const addDecimals = (value: Uint256): number => {
+  return Number(value.toString()) / DECIMALS_QUANTIFIER;
+};

--- a/packages/core/src/utils/math.ts
+++ b/packages/core/src/utils/math.ts
@@ -3,14 +3,35 @@ import { Uint256 } from 'soltypes';
 const TOKEN_DECIMALS = 18;
 const DECIMALS_QUANTIFIER = 10 ** TOKEN_DECIMALS;
 
+/**
+ * Converts bigint to uint256
+ * @param value bigint value
+ * @returns value as uint256
+ */
 export const toUint256 = (value: bigint): Uint256 => {
   return Uint256.from(value.toString());
 };
 
+/**
+ * Removes decimal places to make sure that only integer values live on-chain.
+ * e.g.)
+ *        0.01 -> 10,000,000,000,000,000
+ *        100  -> 100,000,000,000,000,000,000
+ * @param value integer or decimal value
+ * @returns value as uint256
+ */
 export const removeDecimals = (value: number): Uint256 => {
   return toUint256(BigInt(value * DECIMALS_QUANTIFIER));
 };
 
-export const addDecimals = (value: Uint256): number => {
+/**
+ * Restores decimal places (mainly for display purpose).
+ * e.g.)
+ *        10,000,000,000,000,000 -> 0.01
+ *        100,000,000,000,000,000,000 -> 100
+ * @param value uint256 value
+ * @returns value as number (i.e., integer or decimal)
+ */
+export const restoreDecimals = (value: Uint256): number => {
   return Number(value.toString()) / DECIMALS_QUANTIFIER;
 };


### PR DESCRIPTION
## 🎨 Overview
Fixed the decimal handling when transferring JPYC tokens to ensure that the intended amount is accurately sent. This fix resolves the discrepancy between the user-specified amount and the actual transfer amount on the blockchain.

## 🌈 Details
- Added a `DECIMALS` constant to support JPYC's 18 decimal places
- Modified the `balanceOf` method to convert on-chain values to human-readable format
- Updated the `transfer` method to adjust user-specified values by 18 decimal places for on-chain transactions
- Similar modifications will need to be applied to other token operation methods (`transferFrom`, `mint`, `approve`, etc.) in the future
- Implemented `BigInt` for accurate numerical calculations in the SDK

This fix resolves the issue where attempting to send 100 JPYC previously resulted in only 0.0000000000000001 JPYC being transferred, ensuring that the intended 100 JPYC is now correctly sent.

## 📚 References
When transfer below code
```typescript
const txHash = await jpyc.transfer({
      to: receiverAddress,
      value: Uint256.from('100'),
    });
```
- Before fix
https://sepolia.etherscan.io/tx/0x8ce14ea33b9f2f43a89c9bf2e05ea160fa1bc335e07f972b1bda076ee6bcb7bb
- After fix
https://sepolia.etherscan.io/tx/0x009c5970ff0db05a120fcb9cd2d4b004fe460d84fe7080808a067eb4497d22e7